### PR TITLE
Support generation of codes without resetting

### DIFF
--- a/yachalk/chalk_builder.py
+++ b/yachalk/chalk_builder.py
@@ -24,7 +24,7 @@ class ChalkBuilder:
 
         if len(args) == 0:
             return all_on
-        if len(args) == 1 and isinstance(args[0], str):
+        elif len(args) == 1 and isinstance(args[0], str):
             s = args[0]
         else:
             s = sep.join([str(arg) for arg in args])

--- a/yachalk/chalk_builder.py
+++ b/yachalk/chalk_builder.py
@@ -17,17 +17,16 @@ class ChalkBuilder:
     def __init__(self, mode: ColorMode, codes: List[Code]):
         self._mode = mode
         self._codes = codes
+        self._reset = True
 
     def __call__(self, *args: object, sep: str = " ") -> str:
-        all_on = "".join([code.on for code in self._codes])
-        all_off = "".join([code.off for code in self._codes])
-
-        if len(args) == 0:
-            return all_on
-        elif len(args) == 1 and isinstance(args[0], str):
+        if len(args) == 1 and isinstance(args[0], str):
             s = args[0]
         else:
             s = sep.join([str(arg) for arg in args])
+
+        all_on = "".join([code.on for code in self._codes])
+        all_off = "".join([code.off for code in self._codes])
 
         if "\u001b" in s:
             for code in self._codes:
@@ -53,7 +52,7 @@ class ChalkBuilder:
                 s,
             )
 
-        return all_on + s + all_off
+        return all_on + s + ('',all_off)[self._reset]
 
     # General style function
 
@@ -69,6 +68,11 @@ class ChalkBuilder:
     @property
     def reset(self) -> "ChalkBuilder":
         self.style(Mod.reset)
+        return self
+
+    @property
+    def nr(self) -> "ChalkBuilder":
+        self._reset = False
         return self
 
     @property

--- a/yachalk/chalk_builder.py
+++ b/yachalk/chalk_builder.py
@@ -19,13 +19,15 @@ class ChalkBuilder:
         self._codes = codes
 
     def __call__(self, *args: object, sep: str = " ") -> str:
+        all_on = "".join([code.on for code in self._codes])
+        all_off = "".join([code.off for code in self._codes])
+
+        if len(args) == 0:
+            return all_on
         if len(args) == 1 and isinstance(args[0], str):
             s = args[0]
         else:
             s = sep.join([str(arg) for arg in args])
-
-        all_on = "".join([code.on for code in self._codes])
-        all_off = "".join([code.off for code in self._codes])
 
         if "\u001b" in s:
             for code in self._codes:


### PR DESCRIPTION
Sometimes it would be nice to generate colour codes without requiring the text to be coloured be passed as arguments (i.e. avoid the auto reset _sometimes_. This could I guess be flagged as "yachalk can do this, but caveat emptor")

This PR allows generation of colour codes by simply calling the Builder class with no arguments:

```python
white_on_red = chalk.light_white.bg_red()
reset = chalk.reset()

print(white_on_red + 'CRIT' + reset)
```

That's a really bad example, but this allows the usage of yachalk when trying to dynamically colour output from the python logging module with the usage of some custom format expansion arguments. yachalk has a better selection of colour names compared to other colouring packages, which is why I want to add this to yachalk, instead of using an alternative.

An example of how I'd use this feature is like so:

```python
clvl = chalk.green() # this is a simple example, actual usage selects the correct colour for the logging level
cend = chalk.reset()
fmt = f'%(asctime)s %(name)s [{clvl}%(levelname)s{cend}]: %(message)s'
formatter = logging.Formatter(fmt=fmt, datefmt='%Y-%m-%d %H:%M:%S')
```
There's extra code that I use that also performs substitutions on the `%(message)s` argument passed to the `logger` object, using a selection of predefined colour shortcodes, with an implicit `{cend}` appended to reset all, but that's a little out of scope for here.