### PR TITLE
Added the `inverse` style modification method

### DIFF
--- a/yachalk/chalk_builder.py
+++ b/yachalk/chalk_builder.py
@@ -9,6 +9,7 @@ from .ansi import (
     BgColor,
     Ansi16Code,
     wrap_ansi_16,
+    inverse
 )
 from .utils import get_code_from_rgb, hex_to_rgb
 
@@ -102,6 +103,11 @@ class ChalkBuilder:
     @property
     def strikethrough(self) -> "ChalkBuilder":
         self.style(Mod.strikethrough)
+        return self
+
+    @property
+    def inverse(self) -> "ChalkBuilder":
+        self._codes = list(map(inverse, self._codes))
         return self
 
     # Foreground colors


### PR DESCRIPTION
I wasn't able to find the `inverse` style modification mentioned in the `README.md` after further investigations I found that the `inverse` style modification is not implemented so I implemented it myself.

I did not use the `CSI 7 m` as it is not widely supported, I implemented my own system which converts the foreground to background and the background to the foreground